### PR TITLE
fix: upgrade libgc to 8.2.8

### DIFF
--- a/beepy_drivers/package/libgc/libgc.mk
+++ b/beepy_drivers/package/libgc/libgc.mk
@@ -1,4 +1,4 @@
-LIBGC_VERSION = 8.2.6
+LIBGC_VERSION = 8.2.8
 LIBGC_SOURCE = libgc_$(LIBGC_VERSION).orig.tar.gz
 LIBGC_SITE = http://deb.debian.org/debian/pool/main/libg/libgc
 


### PR DESCRIPTION
As of 2024-10-14, http://ftp.debian.org/debian/pool/main/libg/libgc/ no longer contains 8.2.6. It contains 8.2.2 and 8.2.8.

Upgrading resolves the following build error, [encountered](https://github.com/michaelstepner/beepy-buildroot/actions/runs/11537131012) while building 9da98a5:

```
2024-10-27T05:11:25.5600774Z >>> libgc 8.2.6 Downloading
2024-10-27T05:11:25.5727339Z wget --passive-ftp -nd -t 3 -O '/home/runner/work/beepy-buildroot/beepy-buildroot/buildroot/output/build/.libgc_8.2.6.orig.tar.gz.adMkBB/output' 'http://deb.debian.org/debian/pool/main/libg/libgc/libgc_8.2.6.orig.tar.gz' 
2024-10-27T05:11:25.5747210Z --2024-10-27 05:11:25--  http://deb.debian.org/debian/pool/main/libg/libgc/libgc_8.2.6.orig.tar.gz
2024-10-27T05:11:25.5799192Z Resolving deb.debian.org (deb.debian.org)... 151.101.50.132, 2a04:4e42:2f::644
2024-10-27T05:11:25.5817422Z Connecting to deb.debian.org (deb.debian.org)|151.101.50.132|:80... connected.
2024-10-27T05:11:25.7613047Z HTTP request sent, awaiting response... 404 Not Found
2024-10-27T05:11:25.7614338Z 2024-10-27 05:11:25 ERROR 404: Not Found.
```