### PR TITLE
feat: add docker config to build locally and in GHA

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+.git/
+.github/
+docker/

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,22 +8,24 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
+
     - name: Checkout repository
       uses: actions/checkout@v4
       with:
         submodules: True
-    - name: Install packages
+
+    - name: Build docker image
+      run: docker build --platform linux/amd64 --file docker/Dockerfile --tag buildroot-os-builder .
+
+    - name: Build Buildroot OS image for SD card using docker
       run: |
-        sudo apt-get update
-        sudo apt-get install -y make gcc g++ unzip git bc python device-tree-compiler mtd-utils
-    - name: Build image
-      run: |
-        ./build-image.sh
+        docker run --platform linux/amd64 --name my-beepy-buildroot buildroot-os-builder ./build-image.sh
+        docker cp my-beepy-buildroot:/home/builder/beepy-buildroot/buildroot/output/images/sdcard.img ./sdcard.img
+
     - name: Upload SD card image
       uses: actions/upload-artifact@v4
       with:
         name: sdcard.img
-        path: buildroot/output/images/sdcard.img
-
+        path: sdcard.img

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /buildroot/
 /root_overlay/var/lib/iwd/*.psk
+sdcard.img

--- a/README.md
+++ b/README.md
@@ -37,6 +37,6 @@ The username is `beepy` and the password is `beepbeep`. You should change this f
 
 ## Building SD card image from source
 
-Run `./build-image.sh`. This will download Buildroot and build a Beepberry SD card image at `buildroot/output/images/sdcard.img`.
+- ☁️ Cloud: Run the Github Actions build, wait approximately 3 hours, download the `sdcard.img` file.
 
-For subsequent builds you can just run `make -j $(nproc)` from the `buildroot` directory.
+- 💻 Local: For advice about local builds, see the [README in the docker subdirectory](./docker/README.md).

--- a/build-image.sh
+++ b/build-image.sh
@@ -1,19 +1,31 @@
 #!/bin/sh
-
 set -e
+
+# Parse the optional -j argument, which specifies the number of parallel jobs during make
+while getopts "j:" opt; do
+  case $opt in
+    j) cpus=$OPTARG;;
+    \?) echo "Usage: $0 [-j number_of_jobs]" >&2; exit 1;;
+  esac
+done
+
+# If -j unspecified, default number of jobs is the number of processors
+if [ -z "$cpus" ]; then
+  cpus=$(nproc)
+fi
 
 # Download Buildroot
 if [ ! -d buildroot ]; then
-curl https://buildroot.org/downloads/buildroot-2024.02.tar.xz | tar xJ
-mv buildroot-* buildroot
+  curl https://buildroot.org/downloads/buildroot-2024.02.tar.xz | tar xJ
+  mv buildroot-* buildroot
 fi
 
 # `make linux-savedefconfig` to save defconfig
 # it's stored in buildroot/output/build/linux-custom/defconfig
 
 cd buildroot
-make -j $(nproc) defconfig BR2_EXTERNAL=../beepy_drivers BR2_DEFCONFIG=../br_defconfig
-make -j $(nproc)
+make -j "$cpus" defconfig BR2_EXTERNAL=../beepy_drivers BR2_DEFCONFIG=../br_defconfig
+make -j "$cpus"
 echo "Image built at buildroot/output/images/sdcard.img"
 
 # After changing a br_defconfig option for a package, run `make <pkg>-dirclean>, then rebuild

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,29 @@
+# This Dockerfile is based on .github/workflows/build.yml and the official Buildroot Vagrantfile:
+# https://gitlab.com/buildroot.org/buildroot/-/blob/master/support/misc/Vagrantfile
+
+FROM ubuntu:24.04
+
+# Copy the git repository to the container
+COPY ../ /home/builder/beepy-buildroot
+
+# Update and install necessary packages; create non-root user
+RUN apt-get update \
+    && DEBIAN_FRONTEND=noninteractive apt-get install --yes \
+    build-essential libncurses5-dev \
+    git bzr cvs mercurial subversion libc6 unzip bc \
+    make gcc g++ device-tree-compiler mtd-utils \
+    wget curl file \
+    cpio rsync \
+    locales \
+    && apt-get -q -y autoremove \
+    && apt-get -q -y clean \
+    && update-locale LC_ALL=C \
+    && useradd -m -s /bin/bash builder \
+    && passwd -d builder \
+    && usermod -aG sudo builder \
+    && mkdir -p /home/builder/beepy-buildroot \
+    && chown -R builder:builder /home/builder
+
+# Switch to the non-root user
+USER builder
+WORKDIR /home/builder/beepy-buildroot

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,53 @@
+☁️ For instructions on building yourself an SD card image in the cloud using Github Actions, see the [main README](../README.md#instructions).
+
+💻 This README contains advice for local builds, troubleshooting and development. All commands should be run from the *root* of the git repository, not from this subdirectory.
+
+## Local Builds
+
+- Build the SD card image in a docker container on your local machine by running:
+
+    ```
+    git submodule init
+    git submodule update
+    docker build --platform linux/amd64 --file docker/Dockerfile --tag buildroot-os-builder .
+    docker run --platform linux/amd64 --name my-beepy-buildroot buildroot-os-builder ./build-image.sh
+    docker cp my-beepy-buildroot:/home/builder/beepy-buildroot/buildroot/output/images/sdcard.img ./sdcard.img
+    ```
+
+- You can clean up the docker resources once you're done by running:
+
+    ```
+    docker rm my-beepy-buildroot
+    docker rmi buildroot-os-builder
+    ```
+
+## Troubleshooting
+
+- When building on a Mac with Apple Silicon, you might need to limit your docker container to a single CPU to resolve a `write jobserver: Bad file descriptor.  Stop.` error. To do so, we can add `--cpus=1` as an argument to the `docker run` command and add `-j 1` as an argument to the `./build-image.sh` command run within the container:
+
+    ```
+    docker run --platform linux/amd64 --cpus=1 --name my-beepy-buildroot buildroot-os-builder ./build-image.sh -j 1
+    ```
+
+- When building on a Windows PC using WSL (Windows Subsystem for Linux), you might encounter errors related to timestamps such as `Clock skew detected.` This is a [known issue](https://github.com/microsoft/WSL/issues?q=is:issue%20clock%20skew) with WSL. Launching the docker build from an [Ubuntu Multipass](https://multipass.run/) container instead of a WSL2 ubuntu container resolved the issue.
+
+## Development
+
+- When developing or modifying the build, it is useful to do so from an interactive terminal so you can resume crashed builds and inspect the build artifacts created. Instead of the `docker run` command given above, you can run:
+
+    ```
+    docker run -it --platform linux/amd64 --name my-beepy-buildroot buildroot-os-builder /bin/bash
+    ```
+
+- Inside the docker container, you can manually execute:
+
+    ```
+    ./build-image.sh
+    ```
+
+- To re-use the compiler cache in a subsequent build in the same docker container (e.g. to resume a build after it crashes), you can run:
+
+    ```
+    cd buildroot
+    make -j $(nproc)
+    ```


### PR DESCRIPTION
### Also:
- The docker image uses the latest Ubuntu LTS release
- Add README documentation for building locally using docker
- Mention building in the cloud in README doc
- Add support for controlling number of CPUs allocated to build

## Tradeoffs

This will improve reproducibility of builds and ease of building on different platforms.

Previously, every change needed to be tested twice: locally and in the cloud, since there might be subtle differences in behaviour between the Docker image and the Github-provided runner.

- **Upside:** there's only one build system to test and support, since Docker is used locally and in the cloud.
- **Downside:** runs more slowly on systems where the build could be run without docker. For example, in GitHub Actions, it takes an extra:
    - ~20 minutes for a ~2 hour build in a public repository
    - ~30 minutes for a ~3 hour build in a private repository
    - = ~17% overhead