### PR TITLE
chore: upgrade buildroot to 2024.02.7

### DIFF
--- a/build-image.sh
+++ b/build-image.sh
@@ -16,7 +16,7 @@ fi
 
 # Download Buildroot
 if [ ! -d buildroot ]; then
-  curl https://buildroot.org/downloads/buildroot-2024.02.tar.xz | tar xJ
+  curl https://buildroot.org/downloads/buildroot-2024.02.7.tar.xz | tar xJ
   mv buildroot-* buildroot
 fi
 


### PR DESCRIPTION
As of 2024-10-29, the latest bugfix/security patch release of the Buildroot LTS release is 2024.02.7:

[Release announcement](https://lore.kernel.org/buildroot/87h695ap01.fsf@dell.be.48ers.dk/T/#u):
> Buildroot 2024.02.7 is a bugfix release on the current long term
> release, fixing a number of important / security related issues
> discovered since the 2024.02.6 release.

[Versioning according to the Buildroot user manual](https://buildroot.org/downloads/manual/manual.html#_releases):
> The Buildroot project makes quarterly releases with monthly bugfix releases. The first release of each year is a long term support release, LTS.
> 
> Quarterly releases: 2020.02, 2020.05, 2020.08, and 2020.11
> Bugfix releases: 2020.02.1, 2020.02.2, …
> LTS releases: 2020.02, 2021.02, …
> Releases are supported until the first bugfix release of the next release, e.g., 2020.05.x is EOL when 2020.08.1 is released.
> 
> LTS releases are supported until the first bugfix release of the next LTS, e.g., 2020.02.x is supported until 2021.02.1 is released.