### PR TITLE
feat: reduce GHA disk usage with btrfs compression

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,6 +16,28 @@ jobs:
       with:
         submodules: True
 
+    - name: Disable Buildroot compiler cache to reduce disk space usage
+      run: sed -i '/^BR2_CCACHE=y$/d' br_defconfig
+
+    - name: Set up BTRFS file system with compression
+      run: |
+        df -h
+        dd if=/dev/zero of=../virtual_disk.img bs=1M count=12288
+        sudo mkfs.btrfs ../virtual_disk.img
+        sudo mkdir /mnt/virtual-btrfs
+        sudo mount -o loop,compress=zstd ../virtual_disk.img /mnt/virtual-btrfs
+        df -h
+
+    - name: Configure Docker to store containers on BTRFS file system
+      run: |
+        # The compression allows us to store more data than the physical disk space
+        # which works around the limit provided by default Github Actions runners.
+        # Without this workaround, we would narrowly run out of space.
+        sudo systemctl stop docker
+        jq '. + { "storage-driver": "btrfs", "data-root": "/mnt/virtual-btrfs" }' /etc/docker/daemon.json | sudo tee /etc/docker/daemon.json.tmp && sudo mv /etc/docker/daemon.json.tmp /etc/docker/daemon.json
+        sudo systemctl start docker
+        docker info
+
     - name: Build docker image
       run: docker build --platform linux/amd64 --file docker/Dockerfile --tag buildroot-os-builder .
 
@@ -23,6 +45,12 @@ jobs:
       run: |
         docker run --platform linux/amd64 --name my-beepy-buildroot buildroot-os-builder ./build-image.sh
         docker cp my-beepy-buildroot:/home/builder/beepy-buildroot/buildroot/output/images/sdcard.img ./sdcard.img
+
+    - name: Check disk space usage
+      run: |
+        df -h
+        sudo btrfs filesystem usage /mnt/virtual-btrfs
+        sudo btrfs filesystem df /mnt/virtual-btrfs
 
     - name: Upload SD card image
       uses: actions/upload-artifact@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,9 +30,9 @@ jobs:
 
     - name: Configure Docker to store containers on BTRFS file system
       run: |
-        # The compression allows us to store more data than the physical disk space
-        # which works around the limit provided by default Github Actions runners.
-        # Without this workaround, we would narrowly run out of space.
+        # The compression allows us to store more data than the physical disk space,
+        # which ensures we don't exceed the space provided on GitHub-hosted runners.
+        # The disk space available is smaller in private repos than in public repos.
         sudo systemctl stop docker
         jq '. + { "storage-driver": "btrfs", "data-root": "/mnt/virtual-btrfs" }' /etc/docker/daemon.json | sudo tee /etc/docker/daemon.json.tmp && sudo mv /etc/docker/daemon.json.tmp /etc/docker/daemon.json
         sudo systemctl start docker


### PR DESCRIPTION
Reduces the disk space used while building Buildroot OS on GitHub actions by:

- Storing the docker image in a BTRFS filesystem which uses [zstd compression](https://btrfs.readthedocs.io/en/stable/Compression.html).
- Disabling Buildroot's [compiler cache](https://buildroot.org/downloads/manual/manual.html#ccache) to further reduce disk used.

BTRFS+zstd has a much larger effect on the disk space usage (a few GB) than the compiler cache (~100 MB). But the compiler cache is only useful during a second build, and we're discarding the files after each GitHub Actions build.

## Context

GitHub Actions provides more powerful GitHub-hosted runners by default to public repositories than private repositories. The [documentation](https://docs.github.com/en/actions/using-github-hosted-runners/using-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories) indicates that GitHub-hosted runners on both public and private repos receive 14GB of storage, but my own observations (in October 2024) show the public repo runner has ~21GB of free space and the private repo runner has ~18GB of free space.

During testing (in October 2024) without this patch, the "Build image" GHA builds successfully in a public repo but runs out of disk space in a private repo. With this patch, the Buildroot OS builds successfully in both public and private repos.