### PR TITLE
fix: use DNS entries managed by NetworkManager

### DIFF
--- a/post-build.sh
+++ b/post-build.sh
@@ -73,3 +73,6 @@ for python_dir in ${TARGET_DIR}/usr/lib/python3.*; do
 		done
 	fi
 done
+
+# Point DNS entries in resolv.conf to file managed by NetworkManager
+ln -sf ../run/NetworkManager/resolv.conf ${TARGET_DIR}/etc/resolv.conf


### PR DESCRIPTION
# Issue

After connecting to a wifi network on a fresh build, the DNS servers are not propagated to `resolv.conf` and DNS resolution doesn't work:

```
$ ping google.com
ping: bad address 'google.com'
```

The DNS servers are recognized by NetworkManager:

```
$ sudo nmcli dev show | grep 'DNS'
IP4.DNS[1]:                             192.168.2.1
```

The `/etc/resolv.conf` file is a symlink to `/tmp/resolv.conf`:

```
$ ls -l /etc/resolv.conf
lrwxrwxrwx    1 root     root            18 Oct 21  2024 /etc/resolv.conf -> ../tmp/resolv.conf
```

But `/tmp/resolv.conf` is not being created automatically:

```
$ cat /tmp/resolv.conf
cat: can't open '/tmp/resolv.conf': No such file or directory
```

Yet NetworkManager is automatically populating a `resolv.conf` entry in `/run/NetworkManager/resolv.conf`:

```
$ cat /run/NetworkManager/resolv.conf
# Generated by NetworkManager
search home
nameserver 192.168.2.1
```

# Context

This was not an issue in the [v1.2 release](https://github.com/ardangelo/beepberry-buildroot/releases/tag/v1.2) of the beepy-buildroot OS built by ardangelo. But that image is based on Buildroot `2023.02`. I suspect the regression happened due to an upgrade of Buildroot OS.

# Solution

Change symlink from `/etc/resolv.conf -> ../tmp/resolv.conf` to `/etc/resolv.conf -> ../run/NetworkManager/resolv.conf`.