### PR TITLE
fix: prevent noisy kernel messages printed to terminal

### DIFF
--- a/post-build.sh
+++ b/post-build.sh
@@ -76,3 +76,7 @@ done
 
 # Point DNS entries in resolv.conf to file managed by NetworkManager
 ln -sf ../run/NetworkManager/resolv.conf ${TARGET_DIR}/etc/resolv.conf
+
+# Reduce verbosity of kernel messages printed to the terminal
+echo 'kernel.printk = 3 4 1 3' >> ${TARGET_DIR}/etc/sysctl.conf
+chmod 644 ${TARGET_DIR}/etc/sysctl.conf


### PR DESCRIPTION
Prevents terminal messages like:

```
ieee80211 phy0: brcmf_p2p_send_action_frame: Unknown Frame: category 0x5, action 0x4
```