### PR TITLE
feat: customize OS using GitHub Actions inputs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,49 @@ on:
     tags:
       - '*'
   workflow_dispatch:
+    inputs:
+      timezone:
+        type: choice
+        description: Time zone
+        options:
+          - Hawaii
+          - Alaska
+          - Pacific Time (US and Canada)
+          - Mountain Time (US and Canada)
+          - Central Time (US and Canada)
+          - Eastern Time (US and Canada)
+          - Atlantic Time (Canada)
+          - Newfoundland (Canada)
+          - UTC
+          - Western European Time
+          - Central European Time
+          - Eastern European Time
+          - Israel
+          - Moscow Time
+          - India
+          - China
+          - Japan
+          - Korea
+          - New Zealand
+        default: 'UTC'
+      fontsize:
+        type: choice
+        description: Terminal font size
+        options:
+          - small (50 cols x 30 rows)
+          - larger (50 cols x 15 rows)
+      hostname:
+        description: "Hostname (default=buildroot)"
+      wifi_ssid:
+        description: Wifi network name (optional)
+      wifi_password:
+        description: Wifi network password (optional)
+      ssh_authorized_key:
+        description: SSH authorized public key (optional)
+      max_2_cores:
+        description: Max 2 cores to limit peak power use
+        type: boolean
+        default: false
 
 jobs:
   build:
@@ -15,6 +58,25 @@ jobs:
       uses: actions/checkout@v4
       with:
         submodules: True
+
+    - name: Note in GHA Summary that this is a vanilla build
+      run: |
+        echo "🔨 Creating a vanilla Buildroot OS image with no customization." | tee -a $GITHUB_STEP_SUMMARY
+        if [ "${{ github.event_name }}" == "workflow_dispatch" ] && [ "${{ github.repository_visibility }}" != "private" ]; then
+          echo "" | tee -a $GITHUB_STEP_SUMMARY
+          echo 'NOTE: This GitHub Action will only apply customization settings in a *private* GitHub repository.' | tee -a $GITHUB_STEP_SUMMARY
+        fi
+      if: github.event_name != 'workflow_dispatch' || github.event.repository.visibility != 'private'
+
+    - name: Store inputs as a config file and print customization settings to GHA Summary
+      run: |
+        echo '${{ toJSON(inputs) }}' > customization.json
+        echo '###🛠️ Customization settings' | tee -a $GITHUB_STEP_SUMMARY
+        echo '' | tee -a $GITHUB_STEP_SUMMARY
+        echo '```yaml' >> $GITHUB_STEP_SUMMARY
+        cat customization.json | tee -a $GITHUB_STEP_SUMMARY
+        echo '```' >> $GITHUB_STEP_SUMMARY
+      if: github.event_name == 'workflow_dispatch' && github.event.repository.visibility == 'private'
 
     - name: Disable Buildroot compiler cache to reduce disk space usage
       run: sed -i '/^BR2_CCACHE=y$/d' br_defconfig

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /buildroot/
 /root_overlay/var/lib/iwd/*.psk
 sdcard.img
+customization.json

--- a/README.md
+++ b/README.md
@@ -1,42 +1,82 @@
-# Beepberry Buildroot
+# Beepy: Build-Your-Own Buildroot OS
 
-Buildroot is a slimmed-down, Beepy-centric image with a fast boot, compatible with the Raspberry Pi Zero 2 W. It is automatically set up with Beepy device drivers and a set of useful software. Tailored for on-the-go communication, it ships with the following applications:
+This repository provides a lightweight [Buildroot-based](#about-beepys-buildroot-os) OS image for your Beepy, and a friendly user interface to help you generate a personalized OS image.
 
-* `gomuks` - Beeper command line client
-* `mosh` - Mobile remote shell
-* `w3m` - Text based browser
-* `aerc` - Command line email client
-* `nmtui` - Network management
-* Python 3 with `pip`
+- **Option 1:** [Download a pre-built Buildroot OS image](https://github.com/michaelstepner/beepy-buildroot/releases), flash it onto your SD card, pop it into your Beepy, then configure the settings.
+    - ℹ️ Make sure you've updated your Beepy's [firmware](https://github.com/ardangelo/beepberry-rp2040/releases/) version. The latest Buildroot OS images have been tested with firmware version 3.8.
+    - ⚠️ After booting into Buildroot OS, use `passwd` to change the default password and consider turning off password-based SSH authentication for extra security.
 
-Please install [firmware version 3.4](https://github.com/ardangelo/beepberry-rp2040/releases/tag/v3.4) for this Buildroot release.
+- **Option 2:** Follow the [instructions](#instructions-for-building-your-own-os-image) below to build your own Buildroot OS image with your configuration already built into the image.
+    - ✨ When you download the custom image you've generated, your settings are already built-in: wifi network config, SSH authorized keys, time zone, hostname, etc.
 
-## Pre-boot configuration: WiFi network and timezone
+## Instructions for building your own OS image
 
-After flashing the SD image, configuration files added to `/boot/wlan` will be copied to the IWD directory.
+These instructions explain how to create a custom OS image in the cloud, without configuring a build environment on your local computer. It will take about 3.5 hours to compile an OS image in the cloud. For advice about local builds, see the [README in the docker subdirectory](./docker/README.md).
 
-You can rename and rename the file `/boot/wlan/ssid_goes_here.psk` to `/boot/wlan/<your_network_name>.psk` and edit its contents, replacing `passphrase_goes_here` with the network passphrase.
+### Step 0: 🌟 Star this repo (optional)
 
-After booting, You can use the `nmtui` utility to configure Wi-Fi.
+- Starring this repository will let me know this has been useful to you!
 
-The file `timezone.txt` on the SD card's boot partition can be edited to change the device timezone. When a network is connected, time will automatically synchronize with time servers.
+### Step 1: 🔐 Manually copy this repo to a private repo
 
-## Usage
+- You'll be building your own custom Buildroot OS image using GitHub Actions in a *private* GitHub repository, because your personal configuration might contain some private information.
 
-For keybindings and modifier key behaviors, see [`beepy-kbd` documentation](https://github.com/ardangelo/beepberry-keyboard-driver/blob/main/README.md).
+- On a system with `git` and [`gh`](https://cli.github.com/) installed, run the following:
 
-The initial boot will take about 30 seconds to resize disk partitions to fill your SD card. Subsequent boots take around 8 seconds from power-on to Tmux.
+    ```
+    git clone https://github.com/michaelstepner/beepy-buildroot.git my-beepy-buildroot
+    cd my-beepy-buildroot
+    git remote remove origin
+    gh repo create my-beepy-buildroot --private --source=.
+    git push --set-upstream origin main
+    gh repo view my-beepy-buildroot --web
+    ```
 
-When a new Buildroot release is posted, you can update by reflashing the SD card, or by running the command `sudo update_buildroot` to pull the latest changes from the release image.
+### Step 2: 📦 Build your own custom OS image
 
-## Connecting via SSH
+- In the GitHub web interface for your new `my-beepy-buildroot` repository, click on `Actions` then `Build image`.
+- Click the grey `Run workflow ▾` button, and enter your configuration choices.
+    - If you specify an SSH public key, this will be added as an authorized key for the `beepy` user and password-based SSH authentication will be disabled.
+    - ⚠️ If you do not specify an SSH public key, the `beepy` user can be accessed via SSH using the password `beepbeep`. You should change the password using `passwd` and/or disable password-based SSH authentication as soon as possible for security.
+- Click the green `Run workflow` button.
+- After approximately 3.5 hours (measured in October 2024), your GitHub Actions run should complete and your custom image will be ready for download.
 
-SSH is enabled by default, you can configure WiFi as above to connect remotely to debug.
+### Step 3: 🚀 Flash your custom image onto your SD card
 
-The username is `beepy` and the password is `beepbeep`. You should change this from the default using `passwd` as soon as possible for security reasons.
+- In the GitHub web interface for your new `my-beepy-buildroot` repository, click on `Actions` then `Build image`.
+    - After the build has completed successfully, click on the run with the green checkmark.
+- At the bottom of the Summary page, in the Artifacts panel, download `sdcard.img`.
+    - ℹ️ **Recommended:** delete the `sdcard.img` file from the GitHub Artifacts on the summary page once you've downloaded it, so that it ceases to be counted against your limited [Storage for Actions and Packages](https://github.com/settings/billing/summary#usage).
+- Use the [Raspberry Pi Imager tool](https://www.raspberrypi.com/software/) to flash the image to your SD card. (Or an alternative tool if you prefer.)
+    - Raspberry Pi Device: `Raspberry Pi Zero 2 W`
+    - Operating System: scroll all the way to the bottom and select `Use custom`, then select the `sdcard.img.zip` file you just downloaded.
+    - Storage: select your SD card.
+    - Click `Next`.
+    - When prompted "Would you like to apply OS customization settings?" choose `No`. Your customizations are already built into your customized image, and the Raspberry Pi Imager tool isn't able to customize the Buildroot-based OS.
+- 🎁 Insert the SD card you just flashed into your Beepy and enjoy your freshly configured Buildroot-based OS!
+    - The initial boot will take about 30 seconds to resize disk partitions to fill your SD card. Subsequent boots take around 8 seconds from power-on to tmux.
 
-## Building SD card image from source
+## System Requirements
 
-- ☁️ Cloud: Run the Github Actions build, wait approximately 3 hours, download the `sdcard.img` file.
+- Beepy v1 hardware with a Raspberry Pi Zero 2 W and the original Sharp black & white screen.
+- Beepy [firmware version](https://github.com/ardangelo/beepberry-rp2040/releases/) 3.4 or higher installed.
+    - You should ideally use the latest firmware version, and report issues if you encounter problems.
 
-- 💻 Local: For advice about local builds, see the [README in the docker subdirectory](./docker/README.md).
+## About Beepy's Buildroot OS
+
+[Compared to a full-blown Raspbian-based operating system](https://beepy.sqfmi.com/docs/getting-started#3-choose-an-operating-system), a [Buildroot](https://buildroot.org/)-based system is slimmed down, boots fast, and is pre-configured with Beepy device drivers and a set of useful software. Buildroot OS does not have a built-in package manager (like `apt`) that facilitates updates. Instead, packages are compiled at the time the Buildroot OS image is created, and updates are made by building a new SD card with an updated version of Buildroot OS.
+
+Tailored for on-the-go communication, it ships with the following applications:
+
+- `gomuks` - Beeper command line client
+- `mosh` - Mobile remote shell
+- `w3m` - Text based browser
+- `aerc` - Command line email client
+- `nmtui` - Network management
+- Python 3 with `pip`
+
+For keybindings and modifier key behaviors, see an [overview with visual keymaps](https://beepy.sqfmi.com/docs/firmware/keyboard) or the more detailed [`beepy-kbd` documentation](https://github.com/ardangelo/beepberry-keyboard-driver/blob/main/README.md).
+
+## Acknowledgements
+
+This repository is based on the work of [Andrew D'Angelo](http://andrew.uni.cx/) published at [ardangelo/beepberry-buildroot](https://github.com/ardangelo/beepberry-buildroot). The hard work of configuring the Buildroot-based OS for the first time was done by Andrew and the contributors in that repository.

--- a/build-image.sh
+++ b/build-image.sh
@@ -1,6 +1,30 @@
 #!/bin/sh
 set -e
 
+# Apply customizations
+if [ -f customization.json ]; then
+  echo "Applying customizations..."
+
+  keys=$(jq -r 'keys[]' customization.json)
+  for key in $keys; do
+    value=$(jq -r ".$key" customization.json)
+    script_path="./customization_scripts/${key}.sh"
+    if [ ! -f "$script_path" ]; then
+      echo "Error: $key appears in customization.json but $script_path was not found."
+      exit 1
+    elif [ ! -x "$script_path" ]; then
+      echo "Error: $key appears in customization.json $script_path is not executable."
+      echo "Please run 'chmod +x $script_path'."
+      exit 1
+    else
+      echo "  $script_path \"$value\""
+      "$script_path" "$value"
+    fi
+  done
+
+  echo ""
+fi
+
 # Parse the optional -j argument, which specifies the number of parallel jobs during make
 while getopts "j:" opt; do
   case $opt in
@@ -15,14 +39,18 @@ if [ -z "$cpus" ]; then
 fi
 
 # Download Buildroot
+echo "Downloading Buildroot OS..."
 if [ ! -d buildroot ]; then
   curl https://buildroot.org/downloads/buildroot-2024.02.7.tar.xz | tar xJ
   mv buildroot-* buildroot
 fi
+echo ""
 
 # `make linux-savedefconfig` to save defconfig
 # it's stored in buildroot/output/build/linux-custom/defconfig
 
+# Build the SD card image containing Buildroot OS
+echo "Building Buildroot OS..."
 cd buildroot
 make -j "$cpus" defconfig BR2_EXTERNAL=../beepy_drivers BR2_DEFCONFIG=../br_defconfig
 make -j "$cpus"

--- a/customization_scripts/README.md
+++ b/customization_scripts/README.md
@@ -1,0 +1,11 @@
+This folder contains shell scripts which are used by **[build-image.sh](/build-image.sh)** in combination with a **customization.json** file to customize the settings of your Buildroot OS image. This README documents how this process is configured and how to add additional customization options.
+
+### customization.json
+
+The **customization.json** file must be located in the root directory of the repository, adjacent to **build-image.sh**. It is created automatically when you run the "Build image" Github Action manually and enter your customizations in the web GUI.
+
+This JSON file has a single level of hierarchy. For each key-value pair, the key corresponds to the filename of the script in the **[customization_scripts](/customization_scripts)** directory, and the value corresponds to the first (and only) positional argument passed to that script. For example, if **customization.json** contains `"timezone": "Eastern Time (US and Canada)"` then **build-image.sh** will run `./customization_scripts/timezone.sh 'Eastern Time (US and Canada)'` before starting the build.
+
+## Adding a new customization option
+
+To add a new customization option, you need to add the new option as an input to the Github Action defined in **[.github/workflows/build.yml](/.github/workflows/build.yml)** and save a new script that handles this customization in the **[customization_scripts](/customization_scripts)** directory. You can then open a Pull Request to propose the change.

--- a/customization_scripts/fontsize.sh
+++ b/customization_scripts/fontsize.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+set -e
+
+if [ -z "$1" ]; then
+  echo "Error: No argument provided. Please provide a font size."
+  exit 1
+elif [ "$1" = "small (50 cols x 30 rows)" ]; then
+  :
+  # No changes needed, this is the default font size in cmdline.txt
+elif [ "$1" = "larger (50 cols x 15 rows)" ]; then
+  sed -i 's/VGA8x8/VGA8x16/' cmdline.txt
+else
+  echo "Error: '$1' is an unrecognized font size."
+  exit 1
+fi

--- a/customization_scripts/hostname.sh
+++ b/customization_scripts/hostname.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+set -e
+
+if [ -z "$1" ]; then
+  echo "Error: No argument provided. Please provide a hostname."
+  exit 1
+fi
+
+cat << EOF >> post-build.sh
+
+# Modify system hostname
+sed -i 's/buildroot/$1/' \${TARGET_DIR}/etc/hostname
+sed -i 's/buildroot/$1/' \${TARGET_DIR}/etc/hosts
+EOF

--- a/customization_scripts/max_2_cores.sh
+++ b/customization_scripts/max_2_cores.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+set -e
+
+if [ "$1" = "true" ]; then
+  # Restrict CPU to 2 cores to limit peak power use
+  sed -i 's/console=tty1/console=tty1 maxcpus=2/' cmdline.txt
+fi

--- a/customization_scripts/ssh_authorized_key.sh
+++ b/customization_scripts/ssh_authorized_key.sh
@@ -1,0 +1,27 @@
+#!/bin/sh
+set -e
+
+if [ -z "$1" ]; then
+  echo "Error: No argument provided. Please provide an SSH public key."
+  exit 1
+fi
+
+# Configure SSH authorized key for beepy user
+echo "$1" > root_overlay/etc/skel/authorized_keys
+chmod 600 root_overlay/etc/skel/authorized_keys
+
+cat << 'EOC' >> post-build.sh
+
+# Disable password login for SSH
+cat << 'EOF' >> ${TARGET_DIR}/etc/ssh/sshd_config
+
+# Only allow public key authentication
+PasswordAuthentication      no
+PermitEmptyPasswords      no
+ChallengeResponseAuthentication      no
+UsePAM      no
+PermitRootLogin      no
+PubkeyAuthentication      yes
+
+EOF
+EOC

--- a/customization_scripts/timezone.sh
+++ b/customization_scripts/timezone.sh
@@ -1,0 +1,68 @@
+#!/bin/sh
+set -e
+
+# Note that time zones in the Buildroot OS config must be specified in POSIX
+# format (e.g. EST5EDT) rather than the more common IANA format
+# (e.g. America/New_York).
+# 
+# Documentation: https://developer.ibm.com/articles/au-aix-posix/
+#
+# Douglas Adams might have said that "this has made a lot of people very angry
+# and been widely regarded as a bad move" but the POSIX time zone is being used
+# in various places within the Buildroot OS config, so I haven't tried to
+# refactor the code to use the IANA time zone format.
+#
+# This script simply translates a handful of common time zones to their POSIX
+# equivalents.
+#
+# I apologize if your time zone isn't included in this list, there are simply
+# too many time zones. You can manually add your time zone here or enter it
+# directly in timezone.txt in POSIX format.
+
+if [ -z "$1" ]; then
+  echo "Error: No argument provided. Please provide a time zone."
+  exit 1
+elif [ "$1" = "Hawaii" ]; then
+  sed -i 's/UTC0/HST11HDT/' timezone.txt
+elif [ "$1" = "Alaska" ]; then
+  sed -i 's/UTC0/ASKT9AKDT/' timezone.txt
+elif [ "$1" = "Pacific Time (US and Canada)" ]; then
+  sed -i 's/UTC0/PST8PDT/' timezone.txt
+elif [ "$1" = "Mountain Time (US and Canada)" ]; then
+  sed -i 's/UTC0/MST7MDT/' timezone.txt
+elif [ "$1" = "Central Time (US and Canada)" ]; then
+  sed -i 's/UTC0/CST6CDT/' timezone.txt
+elif [ "$1" = "Eastern Time (US and Canada)" ]; then
+  sed -i 's/UTC0/EST5EDT/' timezone.txt
+elif [ "$1" = "Atlantic Time (Canada)" ]; then
+  sed -i 's/UTC0/AST4ADT/' timezone.txt
+elif [ "$1" = "Newfoundland (Canada)" ]; then
+  sed -i 's/UTC0/NST3:30NDT/' timezone.txt
+elif [ "$1" = "UTC" ]; then
+  :
+  # default time zone is already UTC
+elif [ "$1" = "Western European Time" ]; then
+  sed -i 's/UTC0/WET0WEST/' timezone.txt
+elif [ "$1" = "Central European Time" ]; then
+  sed -i 's/UTC0/CET-1CEST/' timezone.txt
+elif [ "$1" = "Eastern European Time" ]; then
+  sed -i 's/UTC0/EET-2EEST/' timezone.txt
+elif [ "$1" = "Israel" ]; then
+  sed -i 's/UTC0/IST-2IDT/' timezone.txt
+elif [ "$1" = "Moscow Time" ]; then
+  sed -i 's/UTC0/MSK-3/' timezone.txt
+elif [ "$1" = "India" ]; then
+  sed -i 's/UTC0/IST-5:30/' timezone.txt
+elif [ "$1" = "China" ]; then
+  sed -i 's/UTC0/CST-8/' timezone.txt
+elif [ "$1" = "Japan" ]; then
+  sed -i 's/UTC0/JST-9/' timezone.txt
+elif [ "$1" = "Korea" ]; then
+  sed -i 's/UTC0/KST-9/' timezone.txt
+elif [ "$1" = "New Zealand" ]; then
+  sed -i 's/UTC0/NZST-12NZDT/' timezone.txt
+else
+  echo "Error: '$1' is an unrecognized time zone."
+  echo "You could manually add it to 'customization_scripts/timezone.sh'"
+  exit 1
+fi

--- a/customization_scripts/wifi_password.sh
+++ b/customization_scripts/wifi_password.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+set -e
+
+if [ -z "$1" ]; then
+  echo "Error: No argument provided. Please provide a wifi password."
+  exit 1
+elif [ ! -f customization.json ]; then
+  echo "Error: customization.json not found in the working directory."
+  exit 1
+fi
+ssid=$(jq -r '.wifi_ssid // ""' customization.json)
+if [ -z "$ssid" ]; then
+  echo "Error: wifi_ssid not found in customization.json."
+  exit 1
+fi
+
+mv "wlan/ssid_goes_here.psk" "wlan/$ssid.psk"
+sed -i "s/passphrase_goes_here/$1/" "wlan/$ssid.psk"

--- a/customization_scripts/wifi_ssid.sh
+++ b/customization_scripts/wifi_ssid.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+set -e
+
+# Only run input validation, no actual configuration, because wifi is configured in wifi_password.sh
+
+if [ -z "$1" ]; then
+  echo "Error: No argument provided. Please provide a wifi SSID."
+  exit 1
+elif [ ! -f customization.json ]; then
+  echo "Error: customization.json not found in the working directory."
+  exit 1
+fi
+pw=$(jq -r '.wifi_password // ""' customization.json)
+if [ -z "$pw" ]; then
+  echo "Error: wifi_password not found in customization.json."
+  exit 1
+fi

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -12,7 +12,7 @@ RUN apt-get update \
     build-essential libncurses5-dev \
     git bzr cvs mercurial subversion libc6 unzip bc \
     make gcc g++ device-tree-compiler mtd-utils \
-    wget curl file \
+    wget curl file jq \
     cpio rsync \
     locales \
     && apt-get -q -y autoremove \

--- a/genimage.cfg
+++ b/genimage.cfg
@@ -13,7 +13,7 @@ image boot.vfat {
       "rpi-firmware/fixup_cd.dat",
       "rpi-firmware/start_cd.elf",
       "../../../timezone.txt",
-	  "../../../wlan",
+      "../../../wlan",
       "zImage"
     }
   }

--- a/root_overlay/etc/init.d/S08firstboot
+++ b/root_overlay/etc/init.d/S08firstboot
@@ -36,7 +36,14 @@ fi
 
 # Set up user directory
 echo "Setting up new user directory"
-mkdir -p /home/beepy
+if [ -f /etc/skel/authorized_keys ]; then
+	mkdir -p /home/beepy/.ssh
+	cp /etc/skel/authorized_keys /home/beepy/.ssh/authorized_keys
+	chmod 700 /home/beepy/.ssh
+	chmod 600 /home/beepy/.ssh/authorized_keys
+else
+	mkdir -p /home/beepy
+fi
 sed -i 's|:/:|:/home/beepy:|g' /etc/passwd
 cp /etc/skel/tmux.conf /home/beepy/.tmux.conf
 cp /etc/skel/profile /home/beepy/.profile


### PR DESCRIPTION
This process for building customized OS images is documented in the main `README.md` and in `customization_scripts/README.md`.

These customizations provide a point-and-click interface (via GitHub Actions) for users to roll their own Buildroot OS image, with built-in personalizations such as:

- wifi settings
- SSH authorized keys
- time zone
- hostname