### PR TITLE
docs: fix markdown heading syntax

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -74,7 +74,7 @@ jobs:
     - name: Store inputs as a config file and print customization settings to GHA Summary
       run: |
         echo '${{ toJSON(inputs) }}' > customization.json
-        echo '###🛠️ Customization settings' | tee -a $GITHUB_STEP_SUMMARY
+        echo '### 🛠️ Customization settings' | tee -a $GITHUB_STEP_SUMMARY
         echo '' | tee -a $GITHUB_STEP_SUMMARY
         echo '```yaml' >> $GITHUB_STEP_SUMMARY
         cat customization.json | tee -a $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
Incorrect markdown heading syntax produced:

![Screenshot 2024-10-30 at 9 51 31 AM](https://github.com/user-attachments/assets/cbaf96af-f058-42a9-9eec-d2264ae7a843)

Fixed markdown heading syntax (with a space between hashes and content) produces:

![Screenshot 2024-10-30 at 9 51 41 AM](https://github.com/user-attachments/assets/3126ba93-8a79-4998-8791-b2663ed6dfd4)
