### PR TITLE
feat: automatically upgrade buildroot using scheduled GHA

### DIFF
--- a/.github/workflows/upgrade_buildroot.yml
+++ b/.github/workflows/upgrade_buildroot.yml
@@ -1,0 +1,132 @@
+name: Upgrade buildroot
+
+on:
+  schedule:
+    - cron: '0 8 * * *'
+  workflow_dispatch:
+
+env:
+  BRANCH_NAME: buildroot-upgrade
+
+jobs:
+  upgrade_buildroot:
+    permissions:
+      contents: write
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+
+      #######################
+      # Configure
+      #######################
+
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Create/checkout new branch
+        run: |
+          branch_exists=$(git ls-remote --heads origin $BRANCH_NAME | wc -l)
+          if [ $branch_exists -eq 1 ]; then
+            git remote set-branches origin $BRANCH_NAME
+            git fetch --depth 1 origin $BRANCH_NAME
+            git checkout $BRANCH_NAME
+          else
+            git checkout -b $BRANCH_NAME
+          fi
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install Python dependencies
+        run: |
+          python3 -m pip install --upgrade pip
+          pip install requests beautifulsoup4
+
+      #######################
+      # Upgrade
+      #######################
+
+      - name: Upgrade buildroot
+        run: ./upgrade_buildroot/upgrade_buildroot.py | tee -a $GITHUB_STEP_SUMMARY
+
+      #######################
+      # Push
+      #######################
+
+      - name: Check if there are changes
+        id: diff
+        run: |
+          set +e
+          test -z "$(git status --porcelain build-image.sh)"
+          echo "VERSION_UPDATED=$?" >> $GITHUB_OUTPUT
+
+          version_number=$(sed -n 's/^buildroot_version="\([^"]*\)"/\1/p' build-image.sh)
+          echo "VERSION_NUMBER=$version_number" >> $GITHUB_OUTPUT
+
+      - name: Commit new data and push to Github
+        run: |
+          git config user.name github-actions[bot]
+          git config user.email github-actions@github.com
+
+          git add build-image.sh
+
+          branch_exists=$(git ls-remote --heads origin $BRANCH_NAME | wc -l)
+          if [ $branch_exists -eq 1 ]; then
+            git branch --set-upstream-to origin/$BRANCH_NAME
+            git pull --ff-only
+            git commit -m "chore: upgrade buildroot to ${{ steps.diff.outputs.VERSION_NUMBER }}"
+            git push origin $BRANCH_NAME
+          else
+            git commit -m "chore: upgrade buildroot to ${{ steps.diff.outputs.VERSION_NUMBER }}"
+            git push --set-upstream origin $BRANCH_NAME
+          fi
+        if: steps.diff.outputs.VERSION_UPDATED == 1
+
+      #######################
+      # Pull Request
+      #######################
+
+      - name: Get existing PR number if it exists
+        id: pr
+        run: |
+          echo "EXISTING_PR_NUM=$(gh pr list --head $BRANCH_NAME | sed 's/^\([0-9]*\).*/\1/g' | head -n 1)" >> $GITHUB_OUTPUT
+          echo "PR_TITLE=chore: upgrade buildroot to ${{ steps.diff.outputs.VERSION_NUMBER }}" >> $GITHUB_OUTPUT
+          echo "PR_BODY=<p>Upgrade to the latest <code>${{ steps.diff.outputs.VERSION_NUMBER }}</code> version of the Buildroot LTS release:</p><ul><li><a href='https://buildroot.org/news.html#:~:text=${{ steps.diff.outputs.VERSION_NUMBER }}%20released'>Announcement</a></li><li><a href='https://gitlab.com/buildroot.org/buildroot/-/blob/${{ steps.diff.outputs.VERSION_NUMBER }}/CHANGES'>Changelog</a></li></ul>" >> $GITHUB_OUTPUT
+        env:
+          GH_TOKEN: ${{ github.token }}
+        if: steps.diff.outputs.VERSION_UPDATED == 1
+
+      - name: Update existing PR details (if PR exists)
+        uses: actions/github-script@v7
+        with:
+          script: |
+            github.request('PATCH /repos/{owner}/{repo}/issues/{issue_number}', {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: ${{ steps.pr.outputs.EXISTING_PR_NUM }},
+              title: "${{ steps.pr.outputs.PR_TITLE }}",
+              body: "${{ steps.pr.outputs.PR_BODY }}"
+            })
+        if: steps.diff.outputs.VERSION_UPDATED == 1 && steps.pr.outputs.EXISTING_PR_NUM != ''
+
+      - name: Create PR (if none exists)
+        run: |
+          gh pr create --base "main" --title "${{ steps.pr.outputs.PR_TITLE }}" --body "${{ steps.pr.outputs.PR_BODY }}"
+        env:
+          GH_TOKEN: ${{ github.token }}
+        if: steps.diff.outputs.VERSION_UPDATED == 1 && steps.pr.outputs.EXISTING_PR_NUM == ''
+
+      - name: Update Github Actions summary with link to PR
+        run: |
+          echo "" >> $GITHUB_STEP_SUMMARY
+          if [ -n "${{ steps.pr.outputs.EXISTING_PR_NUM }}" ]; then
+            echo "➡️ Updated existing PR [#${{ steps.pr.outputs.EXISTING_PR_NUM }}](https://github.com/${{ github.repository }}/pull/${{ steps.pr.outputs.EXISTING_PR_NUM }})" | tee -a $GITHUB_STEP_SUMMARY
+          else
+            NEW_PR_NUM=$(gh pr list --head $BRANCH_NAME | sed 's/^\([0-9]*\).*/\1/g' | head -n 1)
+            echo "➡️ Created new PR [#${NEW_PR_NUM}](https://github.com/${{ github.repository }}/pull/${NEW_PR_NUM})" | tee -a $GITHUB_STEP_SUMMARY
+          fi
+        env:
+          GH_TOKEN: ${{ github.token }}
+        if: steps.diff.outputs.VERSION_UPDATED == 1

--- a/build-image.sh
+++ b/build-image.sh
@@ -1,6 +1,8 @@
 #!/bin/sh
 set -e
 
+buildroot_version="2024.02.7"
+
 # Apply customizations
 if [ -f customization.json ]; then
   echo "Applying customizations..."
@@ -41,7 +43,7 @@ fi
 # Download Buildroot
 echo "Downloading Buildroot OS..."
 if [ ! -d buildroot ]; then
-  curl https://buildroot.org/downloads/buildroot-2024.02.7.tar.xz | tar xJ
+  curl "https://buildroot.org/downloads/buildroot-$buildroot_version.tar.xz" | tar xJ
   mv buildroot-* buildroot
 fi
 echo ""

--- a/upgrade_buildroot/upgrade_buildroot.py
+++ b/upgrade_buildroot/upgrade_buildroot.py
@@ -8,6 +8,7 @@ def find_latest_buildroot_LTS(url: str = "https://buildroot.org/downloads/") -> 
     # Scrape URL
     response = requests.get(url)
     response.raise_for_status()
+    print(f"## Checking releases at {url}")
 
     # Parse the HTML
     soup = BeautifulSoup(response.text, 'html.parser')
@@ -30,8 +31,8 @@ def find_latest_buildroot_LTS(url: str = "https://buildroot.org/downloads/") -> 
     # Find the latest version
     if buildroot_versions:
         latest_version = max(buildroot_versions, key=lambda x: (x[0], x[1]))
-        print(f"Latest LTS version: {latest_version[2]}")
-        print(f"Released on: {latest_version[3]}")
+        print(f"- Latest LTS version: {latest_version[2]}")
+        print(f"- Released on: {latest_version[3]}")
         if latest_version[1] == 0:
             return f"{latest_version[0]}.02"
         else:
@@ -60,9 +61,9 @@ def update_script(latest_version: str, script_path: str = "build-image.sh") -> N
 
     if updated:
         if changed:
-            print(f"🆕 {script_path} updated to use the latest buildroot LTS version")
+            print(f"\n🆕 {script_path} updated to use the latest buildroot LTS version")
         else:
-            print(f"✅ Already using the latest buildroot LTS version in {script_path}")
+            print(f"\n✅ Already using the latest buildroot LTS version in {script_path}")
     else:
         raise ValueError(f"Could not find the buildroot_version line in {script_path}")
 

--- a/upgrade_buildroot/upgrade_buildroot.py
+++ b/upgrade_buildroot/upgrade_buildroot.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+from bs4 import BeautifulSoup
+import fileinput
+import re
+import requests
+
+def find_latest_buildroot_LTS(url: str = "https://buildroot.org/downloads/") -> str:
+    # Scrape URL
+    response = requests.get(url)
+    response.raise_for_status()
+
+    # Parse the HTML
+    soup = BeautifulSoup(response.text, 'html.parser')
+
+    # Regex to match the filenames corresponding to a buildroot LTS release
+    buildroot_pattern = re.compile(r"^buildroot-(\d{4})\.02(?:\.(\d+))?\.tar\.xz$")
+
+    # Extract all releases matching the pattern
+    buildroot_versions = []
+    for link in soup.find_all('a', href=True):
+        match = buildroot_pattern.match(link['href'])
+        if match:
+            year = int(match.group(1))
+            patch = int(match.group(2)) if match.group(2) else 0
+            filename = link['href']
+            release_date = link.parent.find_next('td').get_text()
+            # print(f"Found {filename} released on {release_date}")
+            buildroot_versions.append((year, patch, filename, release_date))
+
+    # Find the latest version
+    if buildroot_versions:
+        latest_version = max(buildroot_versions, key=lambda x: (x[0], x[1]))
+        print(f"Latest LTS version: {latest_version[2]}")
+        print(f"Released on: {latest_version[3]}")
+        if latest_version[1] == 0:
+            return f"{latest_version[0]}.02"
+        else:
+            return f"{latest_version[0]}.02.{latest_version[1]}"
+    else:
+        raise ValueError("No matching versions found.")
+
+
+def update_script(latest_version: str, script_path: str = "build-image.sh") -> None:
+    # Update the build-image.sh script with the latest version
+    version_pattern = re.compile(r'^(buildroot_version=")\d{4}\.02(?:\.\d+)?(")$')
+    
+    updated = False
+    changed = False
+    with fileinput.FileInput(script_path, inplace=True) as file:
+        for line in file:
+            match = version_pattern.match(line)
+            if match:
+                updated_line = f'{match.group(1)}{latest_version}{match.group(2)}'
+                print(updated_line, end='\n')
+                updated = True
+                if match.group(0) != updated_line:
+                    changed = True
+            else:
+                print(line, end='')
+
+    if updated:
+        if changed:
+            print(f"🆕 {script_path} updated to use the latest buildroot LTS version")
+        else:
+            print(f"✅ Already using the latest buildroot LTS version in {script_path}")
+    else:
+        raise ValueError(f"Could not find the buildroot_version line in {script_path}")
+
+
+if __name__ == "__main__":
+    latest_version = find_latest_buildroot_LTS()
+    update_script(latest_version)


### PR DESCRIPTION
Run a Github Action daily to check whether there is a new Buildroot LTS release. If there is an upgrade available, automatically open a PR that upgrades buildroot to the latest LTS release.

## Versioning [according to the Buildroot user manual](https://buildroot.org/downloads/manual/manual.html#_releases)

> The Buildroot project makes quarterly releases with monthly bugfix releases. The first release of each year is a long term support release, LTS.
> 
> Quarterly releases: 2020.02, 2020.05, 2020.08, and 2020.11
> Bugfix releases: 2020.02.1, 2020.02.2, …
> LTS releases: 2020.02, 2021.02, …
>
> Releases are supported until the first bugfix release of the next release, e.g., 2020.05.x is EOL when 2020.08.1 is released.
> 
> LTS releases are supported until the first bugfix release of the next LTS, e.g., 2020.02.x is supported until 2021.02.1 is released.