### PR TITLE
fix: use curl to fetch buildroot releases, fail GHA on error

### DIFF
--- a/.github/workflows/upgrade_buildroot.yml
+++ b/.github/workflows/upgrade_buildroot.yml
@@ -49,7 +49,10 @@ jobs:
       #######################
 
       - name: Upgrade buildroot
-        run: ./upgrade_buildroot/upgrade_buildroot.py | tee -a $GITHUB_STEP_SUMMARY
+        run: |
+          set -o pipefail
+          ./upgrade_buildroot/upgrade_buildroot.py | tee -a $GITHUB_STEP_SUMMARY
+        shell: bash
 
       #######################
       # Push

--- a/.github/workflows/upgrade_buildroot.yml
+++ b/.github/workflows/upgrade_buildroot.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Install Python dependencies
         run: |
           python3 -m pip install --upgrade pip
-          pip install requests beautifulsoup4
+          pip install beautifulsoup4
 
       #######################
       # Upgrade

--- a/upgrade_buildroot/upgrade_buildroot.py
+++ b/upgrade_buildroot/upgrade_buildroot.py
@@ -2,16 +2,27 @@
 from bs4 import BeautifulSoup
 import fileinput
 import re
-import requests
+import subprocess
+
+def fetch_html_with_curl(url: str) -> str:
+    try:
+        result = subprocess.run(
+            ["curl", "-sL", url],  # Silent, follow redirects
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        return result.stdout  # HTML content
+    except subprocess.CalledProcessError as e:
+        raise RuntimeError(f"Failed to fetch URL with curl: {e}")
 
 def find_latest_buildroot_LTS(url: str = "https://buildroot.org/downloads/") -> str:
     # Scrape URL
-    response = requests.get(url)
-    response.raise_for_status()
     print(f"## Checking releases at {url}")
+    html = fetch_html_with_curl(url)
 
     # Parse the HTML
-    soup = BeautifulSoup(response.text, 'html.parser')
+    soup = BeautifulSoup(html, 'html.parser')
 
     # Regex to match the filenames corresponding to a buildroot LTS release
     buildroot_pattern = re.compile(r"^buildroot-(\d{4})\.02(?:\.(\d+))?\.tar\.xz$")


### PR DESCRIPTION
This fixes the Github Actions workflow which automatically upgrades to the latest buildroot LTS release:

1. Use `curl` instead of Python's `requests` package to fetch https://buildroot.org/downloads/.

    - `requests` was giving the following error:

        ```
        requests.exceptions.ChunkedEncodingError: ('Connection broken: IncompleteRead(292758 bytes read, 5338 more expected)', IncompleteRead(292758 bytes read, 5338 more expected))
        ```

    - The error wasn't resolved by using retries, streaming the response incrementally using `chunk_size=1024`, setting headers to mimic a browser, or forcing HTTP/1.1.

2. Use `pipefail` to cause GHA to fail with an error message when the python script exits with an error.

    - Without `pipefail` it was failing silently, ex: [Upgrade buildroot #9](https://github.com/michaelstepner/beepy-buildroot/actions/runs/11852512856)
