### PR TITLE
chore: only run upgrade_buildroot GHA in repos named beepy-buildroot

### DIFF
--- a/.github/workflows/upgrade_buildroot.yml
+++ b/.github/workflows/upgrade_buildroot.yml
@@ -10,6 +10,7 @@ env:
 
 jobs:
   upgrade_buildroot:
+    if: ${{ github.event.repository.name == 'beepy-buildroot' }}
     permissions:
       contents: write
       pull-requests: write


### PR DESCRIPTION
The `upgrade_buildroot` Github Action checks daily to see if there is a new LTS version of Buildroot OS available. If yes, it and opens a PR to upgrade to the newer version.

Doing so requires giving the Github Actions auth token permission to create PRs:
![Screenshot 2024-12-10 at 11 23 03 AM](https://github.com/user-attachments/assets/f31777d8-ef86-492a-8c62-b8dd0f287bde)

This permission is off by default in new repos, which causes the Github Action workflow to fail with a cryptic error message. It's also superfluous to have every person's personal configuration repo checking for a new version separately, rather than just pulling updates from the upstream repo.

This changeset therefore only runs the `upgrade_buildroot` Github Action in repos named `beepy-buildroot`. The suggested name in the README for personal repos with personal config is `my-beepy-buildroot`, and the GHA won't trigger there. But it will trigger by default in forked repos where people are developing changes, since forks preserve the repo name but change owner. And it's trivial for users to modify or remove this condition if needed.