### PR TITLE
fix: increase disk space allocated to BTRFS

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -87,7 +87,7 @@ jobs:
     - name: Set up BTRFS file system with compression
       run: |
         df -h
-        dd if=/dev/zero of=../virtual_disk.img bs=1M count=12288
+        dd if=/dev/zero of=../virtual_disk.img bs=1M count=16384
         sudo mkfs.btrfs ../virtual_disk.img
         sudo mkdir /mnt/virtual-btrfs
         sudo mount -o loop,compress=zstd ../virtual_disk.img /mnt/virtual-btrfs
@@ -116,6 +116,7 @@ jobs:
         df -h
         sudo btrfs filesystem usage /mnt/virtual-btrfs
         sudo btrfs filesystem df /mnt/virtual-btrfs
+      if: always()
 
     - name: Upload SD card image as GitHub Actions artifact
       uses: actions/upload-artifact@v4

--- a/build-image.sh
+++ b/build-image.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 set -e
 
-buildroot_version="2024.02.9"
+buildroot_version="2024.02.10"
 
 # Apply customizations
 if [ -f customization.json ]; then


### PR DESCRIPTION
Also, always check disk space usage at the end of a build, even for failed builds.

This may fix the issues with building Buildroot 2024.02.10 (PR https://github.com/michaelstepner/beepy-buildroot/pull/19), which fails each time on the Github Actions runners due to running out of disk space.

Ex: [build-image 12](https://github.com/michaelstepner/beepy-buildroot/actions/runs/12761246080)