### PR TITLE
fix: create docker daemon.json config if it dne

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -99,7 +99,11 @@ jobs:
         # which ensures we don't exceed the space provided on GitHub-hosted runners.
         # The disk space available is smaller in private repos than in public repos.
         sudo systemctl stop docker
-        jq '. + { "storage-driver": "btrfs", "data-root": "/mnt/virtual-btrfs" }' /etc/docker/daemon.json | sudo tee /etc/docker/daemon.json.tmp && sudo mv /etc/docker/daemon.json.tmp /etc/docker/daemon.json
+        if [ -f /etc/docker/daemon.json ]; then
+          jq '. + { "storage-driver": "btrfs", "data-root": "/mnt/virtual-btrfs" }' /etc/docker/daemon.json | sudo tee /etc/docker/daemon.json.tmp && sudo mv /etc/docker/daemon.json.tmp /etc/docker/daemon.json
+        else
+          jq -n '{ "storage-driver": "btrfs", "data-root": "/mnt/virtual-btrfs" }' | sudo tee /etc/docker/daemon.json
+        fi
         sudo systemctl start docker
         docker info
 
@@ -116,6 +120,7 @@ jobs:
         df -h
         sudo btrfs filesystem usage /mnt/virtual-btrfs
         sudo btrfs filesystem df /mnt/virtual-btrfs
+      if: ${{ !cancelled() }}
 
     - name: Upload SD card image as GitHub Actions artifact
       uses: actions/upload-artifact@v4

--- a/build-image.sh
+++ b/build-image.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 set -e
 
-buildroot_version="2024.02.9"
+buildroot_version="2024.02.10"
 
 # Apply customizations
 if [ -f customization.json ]; then


### PR DESCRIPTION
When Github Actions runners default switched from ubuntu-22.04 to ubuntu-24.04, the build-image GHA started failing due to lack of disk space (ex: [run 12](https://github.com/michaelstepner/beepy-buildroot/actions/runs/12761246080)).

The reason it's running out of disk space is because the "Configure Docker to store containers on BTRFS file system" step was silently failing with the following error:

```
jq: error: Could not open file /etc/docker/daemon.json: No such file or directory
```

This PR modifies the code to check if the `/etc/docker/daemon.json` file exists, and create it if it does not exist.