### PR TITLE
fix: eliminate duplicated branch creation

### DIFF
--- a/upgrade_scripts/git_add_and_push.sh
+++ b/upgrade_scripts/git_add_and_push.sh
@@ -36,12 +36,10 @@ fi
 # Add modified files
 jq -r '.files_modified[]' "$config_file" | xargs git add
 
-# Set up branch tracking and sync with remote if it exists, otherwise create new branch
+# Set up branch tracking and sync with remote if it exists
 if git ls-remote --heads origin "$BRANCH_NAME" | grep -q .; then
     git branch --set-upstream-to "origin/$BRANCH_NAME"
     git pull --ff-only
-else
-    git checkout -b "$BRANCH_NAME"
 fi
 
 git commit -m "$(jq -r '.commit_message' "$config_file")"


### PR DESCRIPTION
Will resolve the error in the upgrade_buildroot GHA (e.g. [run 142](https://github.com/michaelstepner/beepy-buildroot/actions/runs/13941642698)) that was introduced by PR #23. This error occurs when there is a buildroot upgrade to apply, before committing the change:

```
fatal: a branch named 'buildroot-upgrade' already exists
```